### PR TITLE
Fix host controller capabilities for Arasan SDHCI

### DIFF
--- a/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
+++ b/drivers/sd/bcm2836/bcm2836sdhc/bcm2836sdhc.c
@@ -554,7 +554,7 @@ SdhcSlotInitialize (
 
     Capabilities->Supported.Address64Bit = 0;
     Capabilities->Supported.BusWidth8Bit = 0;
-    Capabilities->Supported.HighSpeed = 0;
+    Capabilities->Supported.HighSpeed = 1;
 
     Capabilities->Supported.SDR50 = 0;
     Capabilities->Supported.DDR50 = 0;
@@ -564,7 +564,9 @@ SdhcSlotInitialize (
     Capabilities->Supported.HS200 = 0;
     Capabilities->Supported.HS400 = 0;
 
+    Capabilities->Supported.DriverTypeA = 1;
     Capabilities->Supported.DriverTypeB = 1;
+    Capabilities->Supported.DriverTypeC = 1;
 
     Capabilities->Supported.TuningForSDR50 = 0;
     Capabilities->Supported.SoftwareTuning = 0;
@@ -1604,7 +1606,8 @@ SdhcSetHighSpeed (
     HostControl &= ~SDHC_HC_ENABLE_HIGH_SPEED;
 
     if (Enable) {
-        HostControl |= SDHC_HC_ENABLE_HIGH_SPEED;
+        // Per Linux driver Git history, this is a fix for some timing bug.
+        // HostControl |= SDHC_HC_ENABLE_HIGH_SPEED;
     } // if
 
     SdhcWriteRegisterUlong(SdhcExtension, SDHC_CONTROL_0, HostControl);


### PR DESCRIPTION
The Arasan SD controller has a broken capabilities register, so the capabilities
need to be hardcoded in the driver. This updates the capabilities with the ones
from the official Linux in-kernel driver.

Also apply a bugfix to SetHighSpeed - apparently it's some timing issue.
Not sure if it actually applies to the Arasan, since the commit message only
mentions iProc Cygnus, but the Linux driver applies the fix for Arasan too.

With this, the Arasan's transfer rate should double to 25MB/s.
(NOTE: Windows runs the Arasan at a 250MHz base clock, so due to the
requirement for an even divisor, it will actually run the card slightly slower,
at about 21MB/s. Full 25 is possible once we can run the Arasan at its proper
clock rate of 400 or 500MHz, depending on Pi model.)